### PR TITLE
Remove slash as division

### DIFF
--- a/_index.scss
+++ b/_index.scss
@@ -3,6 +3,8 @@
 //
 // str-replace
 // Modified from https://css-tricks.com/snippets/sass/str-replace-function/
+@use "sass:math";
+
 @function str-replace($string, $search, $replace: "", $special: false) {
   // NB: $special doesn't work for CRLF so yeah, don't
   $index-offset: if($special, -1, 0);
@@ -59,7 +61,7 @@
   $encoded: "";
   $slice: 2000;
   $index: 0;
-  $loops: ceil(str-length($svg) / $slice);
+  $loops: ceil(math.div(str-length($svg), $slice));
   @for $i from 1 through $loops {
     $chunk: str-slice($svg, $index, $index + $slice - 1);
     // Replace various things so as to encode SVG XML for CSS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svg-sass",
-  "version": "1.0.5",
+  "version": "2.0.0",
   "description": "SVG inline encoding for SCSS content or background-image attributes",
   "main": "_index.scss",
   "scripts": {
@@ -16,5 +16,8 @@
     "url": "https://github.com/entozoon/svg-sass/issues"
   },
   "homepage": "https://github.com/entozoon/svg-sass#readme",
-  "dependencies": {}
+  "dependencies": {},
+  "peerDependencies": {
+    "sass": ">=1.33.0"
+  }
 }


### PR DESCRIPTION
Using a slash as a mathematical divison is deprecated. This PR updates the repo to use math.div() and also bumps version to 2.0.0 as there is a new peerDependancy on sass >=1.33.0
https://sass-lang.com/documentation/breaking-changes/slash-div